### PR TITLE
Serverspec2

### DIFF
--- a/spec/network/network_spec.rb
+++ b/spec/network/network_spec.rb
@@ -11,8 +11,8 @@ end
 
 # network
 describe default_gateway do
-  its(properties[:ipaddress]) { should eq p['gw_addr'] }
-  its(properties[:interface]) { should eq p['gw_addr_device'] }
+  its(:ipaddress) { should eq properties[:gw_addr] }
+  its(:interface) { should eq properties[:gw_addr_device] }
 end
 
 describe service('network') do

--- a/spec/os/os_spec.rb
+++ b/spec/os/os_spec.rb
@@ -59,7 +59,7 @@ end
 
 # hostname
 describe command('hostname') do
-  its(:stdout) { should eq p[:hostname] }
+  its(:stdout) { should eq ENV['TARGET_HOST'] }
 end
 
 # selinux

--- a/spec/os/os_spec.rb
+++ b/spec/os/os_spec.rb
@@ -26,7 +26,7 @@ end
 # disable service check
 properties[:disable_services].map do |a|
   describe command('service ' + a + ' status') do
-    it { should_not return_exit_status 0 }
+    its(:exit_status) { should_not eq 0 }
   end
 end
 

--- a/spec/os/os_spec.rb
+++ b/spec/os/os_spec.rb
@@ -13,7 +13,7 @@ end
 
 # アスタリスク "*" が左端に表示され参照中であること
 describe command('ntpq -pn') do
-  it { should return_stdout /^\*\d/}
+  its(:stdout) { should match /^\*\d/ }
 end
 
 # packages install check
@@ -38,7 +38,7 @@ end
 # resolv.conf
 properties[:resolv].map do |s|
   describe command('cat /etc/resolv.conf') do
-    it { should return_stdout s }
+    it { should eq s }
   end
 end
 
@@ -59,7 +59,7 @@ end
 
 # hostname
 describe command('hostname') do
-  it { should return_stdout(p[:hostname]) }
+  its(:stdout) { should eq p[:hostname] }
 end
 
 # selinux
@@ -154,4 +154,3 @@ describe file('/home/src') do
   it { should be_owned_by 'root' }
   it { should be_mode 755 }
 end
-

--- a/spec/php/php_spec.rb
+++ b/spec/php/php_spec.rb
@@ -6,23 +6,23 @@ describe 'PHP config parameters' do
   context php_config('date.timezone') do
     its(:value) { should eq properties[:timezone] }
   end
-  
+
   context php_config('max_execution_time') do
     its(:value) { should eq properties[:max_execution_time] }
   end
-  
+
   context php_config('memory_limit') do
     its(:value) { should eq properties[:memory_limit] }
   end
-  
+
   context php_config('post_max_size') do
     its(:value) { should eq properties[:post_max_size] }
   end
-  
+
   context php_config('upload_max_filesize') do
     its(:value) { should eq properties[:upload_max_filesize] }
   end
-  
+
   context php_config('max_input_time') do
     its(:value) { should eq "#{properties[:max_input_time]}" }
  end
@@ -31,10 +31,9 @@ end
 
 
 describe command('libmcrypt-config --version') do
-  it { should return_stdout properties[:libmcrypt_version] }
+  its(:stdout) { should match properties[:libmcrypt_version] }
 end
 
 describe command('php -v') do
   its(:stdout) { should match /#{properties[:version]}/ }
 end
-

--- a/spec/zabbix-agent/zabbix-agent_spec.rb
+++ b/spec/zabbix-agent/zabbix-agent_spec.rb
@@ -11,5 +11,5 @@ describe service('zabbix-agent') do
 end
 
 describe command('zabbix_agentd -V') do
-  it { should return_stdout /#{properties[:version]}/ }
+  its(:stdout) { should match /#{properties[:version]}/ }
 end


### PR DESCRIPTION
diff: https://github.com/dwango/serverspecd/pull/5/files?w=1
see: http://serverspec.org/changes-of-v2.html

```
You can’t write test code like this anymore.

describe command('ls /tmp') do
  it { should return_stdout 'foo' }
  it { should return_stderr 'bar' }
  it { should return_exit_status 0 }
end

Instead, you must write test code like this.

describe command('ls /tmp') do
  its(:stdout) { should eq "foo\n" }
  its(:stderr) { should match /bar/ }
  its(:exit_status) { should eq 0 }
end
```